### PR TITLE
Fix TypeScript typecheck

### DIFF
--- a/app/components/image-steps.tsx
+++ b/app/components/image-steps.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router'
 import { ImageZoom } from 'fumadocs-ui/components/image-zoom'
 import { cn } from 'fumadocs-ui/utils/cn'
 
-import { i18n, locales } from '@/lib/i18n'
+import { i18n, isLocale } from '@/lib/i18n'
 import { getTranslations } from '@/lib/translations'
 
 export interface Step {
@@ -76,8 +76,8 @@ export function ImageSteps({ title, basePath, steps, className }: ImageStepsProp
   const total = steps.length
 
   const params = useParams()
-  const currentLocale = params.lang && locales.includes(params.lang as string) ? params.lang : i18n.defaultLanguage
-  const t = getTranslations(currentLocale as string)
+  const currentLocale = isLocale(params.lang) ? params.lang : i18n.defaultLanguage
+  const t = getTranslations(currentLocale)
   const fallbackLocale = 'zh'
 
   const goTo = (index: number) => {
@@ -128,7 +128,7 @@ export function ImageSteps({ title, basePath, steps, className }: ImageStepsProp
             src={step.image}
             alt={step.title}
             basePath={basePath}
-            currentLocale={currentLocale as string}
+            currentLocale={currentLocale}
             fallbackLocale={fallbackLocale}
             visible={index === current}
           />

--- a/app/components/localized-image.tsx
+++ b/app/components/localized-image.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useParams } from 'react-router'
 
-import { i18n, locales } from '@/lib/i18n'
+import { i18n, isLocale } from '@/lib/i18n'
 
 interface LocalizedImageProps {
   src: string
@@ -25,7 +25,7 @@ interface LocalizedImageProps {
  */
 export function LocalizedImage({ src, alt, className, width, height }: LocalizedImageProps) {
   const params = useParams()
-  const currentLocale = params.lang && locales.includes(params.lang as string) ? params.lang : i18n.defaultLanguage
+  const currentLocale = isLocale(params.lang) ? params.lang : i18n.defaultLanguage
   const fallbackLocale = 'zh'
 
   const [imgSrc, setImgSrc] = useState(`/assets/images/${currentLocale}/${src}`)

--- a/app/components/search-dialog.tsx
+++ b/app/components/search-dialog.tsx
@@ -5,6 +5,7 @@ import { useDocsSearch } from 'fumadocs-core/search/client'
 import type { SortedResult } from 'fumadocs-core/search'
 import type { SharedProps } from 'fumadocs-ui/components/dialog/search'
 import { useMemo } from 'react'
+import { useLocation } from 'react-router'
 import {
   SearchDialog,
   SearchDialogClose,
@@ -16,6 +17,8 @@ import {
   SearchDialogList,
   SearchDialogOverlay
 } from 'fumadocs-ui/components/dialog/search'
+
+import { getLocaleFromPath } from '@/lib/i18n'
 
 const CJK_REGEX = /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff]/
 
@@ -48,7 +51,11 @@ function initOrama(locale?: string) {
     return create({
       schema: { _: 'string' as const },
       components: {
-        tokenizer: { tokenize: cjkTokenize }
+        tokenizer: {
+          language: ORAMA_LANGUAGES[locale] ?? 'english',
+          normalizationCache: new Map<string, string>(),
+          tokenize: cjkTokenize
+        }
       }
     })
   }
@@ -72,10 +79,12 @@ export default function CustomSearchDialog({
   links = [],
   ...props
 }: Props) {
+  const location = useLocation()
+  const currentLocale = locale ?? getLocaleFromPath(location.pathname)
   const { search, setSearch, query } = useDocsSearch({
     type: 'static',
     from: api,
-    locale,
+    locale: currentLocale,
     delayMs,
     initOrama
   })

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -3,22 +3,23 @@ import { toClientRenderer } from 'fumadocs-mdx/runtime/vite'
 import { DocsLayout } from 'fumadocs-ui/layouts/docs'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/page'
+import type { TOCItemType } from 'fumadocs-core/toc'
 
 import { docs } from '@/.source'
 import { Card, Cards } from '@/components/card'
+import { ConditionalBreadcrumb } from '@/components/conditional-breadcrumb'
 import { ExperienceCard, ExperienceCards } from '@/components/experience-card'
+import { ImageSteps } from '@/components/image-steps'
 import { sidebarComponents } from '@/components/sidebar-components'
-import { i18n, locales } from '@/lib/i18n'
+import { i18n, isLocale } from '@/lib/i18n'
 import { baseOptions } from '@/lib/layout.shared'
 import { getSource } from '@/lib/source'
 
 import type { Route } from './+types/page'
-import {ImageSteps} from "@/components/image-steps";
-import {ConditionalBreadcrumb} from "@/components/conditional-breadcrumb";
 
 export async function loader({ params }: Route.LoaderArgs) {
   const source = await getSource()
-  const lang = params.lang && locales.includes(params.lang) ? params.lang : i18n.defaultLanguage
+  const lang = isLocale(params.lang) ? params.lang : i18n.defaultLanguage
   const slugs = params['*'].split('/').filter((v) => v.length > 0)
   const page = source.getPage(slugs, lang)
   if (!page) throw new Response('Not found', { status: 404 })
@@ -31,9 +32,9 @@ export async function loader({ params }: Route.LoaderArgs) {
 }
 
 const renderer = toClientRenderer(docs.doc, ({ toc, default: Mdx, frontmatter }) => {
-  const fullToc = [
+  const fullToc: TOCItemType[] = [
     { title: frontmatter.title, url: '#page-title', depth: 2 },
-    ...toc.map((item: { title: string; url: string; depth: number }) => ({ ...item, depth: item.depth + 1 }))
+    ...toc.map((item) => ({ ...item, depth: item.depth + 1 }))
   ]
   return (
     <DocsPage toc={fullToc} breadcrumb={{ component: <ConditionalBreadcrumb /> }}>

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -9,6 +9,11 @@ export const i18n = defineI18n({
 })
 
 export const locales = i18n.languages
+export type Locale = (typeof locales)[number]
+
+export function isLocale(value: string | undefined): value is Locale {
+  return Boolean(value && (locales as string[]).includes(value))
+}
 
 export const localeNames: Record<string, string> = {
   en: 'English',
@@ -61,11 +66,11 @@ export const { provider: i18nProvider } = defineI18nUI(i18n, {
   }
 })
 
-export function getLocaleFromPath(pathname: string): string {
+export function getLocaleFromPath(pathname: string): Locale {
   const segments = pathname.split('/').filter(Boolean)
   const firstSegment = segments[0]
 
-  if (firstSegment && locales.includes(firstSegment)) {
+  if (isLocale(firstSegment)) {
     return firstSegment
   }
 
@@ -93,7 +98,7 @@ export function getLocalizedPath(pathname: string, targetLocale: string): string
 /**
  * Detect user's preferred language from browser settings
  */
-export function detectBrowserLocale(): string {
+export function detectBrowserLocale(): Locale {
   if (typeof navigator === 'undefined') {
     return i18n.defaultLanguage
   }
@@ -102,13 +107,13 @@ export function detectBrowserLocale(): string {
 
   for (const browserLang of browserLanguages) {
     // Exact match
-    if (locales.includes(browserLang)) {
+    if (isLocale(browserLang)) {
       return browserLang
     }
 
     // Match by language code (e.g., zh-CN -> zh)
     const langCode = browserLang.split('-')[0]
-    if (locales.includes(langCode)) {
+    if (isLocale(langCode)) {
       return langCode
     }
   }
@@ -118,13 +123,13 @@ export function detectBrowserLocale(): string {
 
 const LOCALE_STORAGE_KEY = 'preferred-locale'
 
-export function getPreferredLocale(): string {
+export function getPreferredLocale(): Locale {
   if (typeof localStorage === 'undefined') {
     return detectBrowserLocale()
   }
 
   const stored = localStorage.getItem(LOCALE_STORAGE_KEY)
-  if (stored && locales.includes(stored)) {
+  if (stored && isLocale(stored)) {
     return stored
   }
 
@@ -132,7 +137,7 @@ export function getPreferredLocale(): string {
 }
 
 export function setPreferredLocale(locale: string): void {
-  if (typeof localStorage !== 'undefined' && locales.includes(locale)) {
+  if (typeof localStorage !== 'undefined' && isLocale(locale)) {
     localStorage.setItem(LOCALE_STORAGE_KEY, locale)
   }
 }

--- a/app/lib/providers.tsx
+++ b/app/lib/providers.tsx
@@ -66,8 +66,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         search={{
           SearchDialog: CustomSearchDialog,
           options: {
-            api: '/api/search.json',
-            locale: currentLocale
+            api: '/api/search.json'
           }
         }}
         i18n={{

--- a/app/lib/translations.ts
+++ b/app/lib/translations.ts
@@ -1,3 +1,48 @@
+import type { Locale } from './i18n'
+
+export type TranslationKeys = {
+  meta: {
+    title: string
+    description: string
+  }
+  home: {
+    title: string
+    subtitle: string
+    description: string
+    getStarted: string
+    deployGuide: string
+  }
+  features: {
+    modelManagement: FeatureTranslation
+    knowledgeBase: FeatureTranslation
+    accessControl: FeatureTranslation
+    privateDeployment: FeatureTranslation
+    backendService: FeatureTranslation
+    security: FeatureTranslation
+  }
+  nav: {
+    docs: string
+  }
+  imageSteps: {
+    step: string
+    prev: string
+    next: string
+    goToStep: string
+  }
+  error: {
+    oops: string
+    unexpected: string
+    notFound: string
+    notFoundMessage: string
+    error: string
+  }
+}
+
+type FeatureTranslation = {
+  title: string
+  description: string
+}
+
 export const translations = {
   en: {
     meta: {
@@ -174,10 +219,7 @@ export const translations = {
       error: 'エラー'
     }
   }
-} as const
-
-export type Locale = keyof typeof translations
-export type TranslationKeys = (typeof translations)['en']
+} as const satisfies Record<Locale, TranslationKeys>
 
 export function getTranslations(locale: string): TranslationKeys {
   return translations[locale as Locale] || translations['en']

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,14 +1,14 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home'
 import { Link, useParams } from 'react-router'
 
-import { i18n, locales } from '@/lib/i18n'
+import { i18n, isLocale } from '@/lib/i18n'
 import { baseOptions } from '@/lib/layout.shared'
 import { getTranslations } from '@/lib/translations'
 
 import type { Route } from './+types/home'
 
 export function meta({ params }: Route.MetaArgs) {
-  const lang = params.lang && locales.includes(params.lang) ? params.lang : i18n.defaultLanguage
+  const lang = isLocale(params.lang) ? params.lang : i18n.defaultLanguage
   const t = getTranslations(lang)
 
   return [{ title: t.meta.title }, { name: 'description', content: t.meta.description }]
@@ -16,7 +16,7 @@ export function meta({ params }: Route.MetaArgs) {
 
 export default function Home() {
   const params = useParams()
-  const lang = params.lang && locales.includes(params.lang) ? params.lang : i18n.defaultLanguage
+  const lang = isLocale(params.lang) ? params.lang : i18n.defaultLanguage
   const t = getTranslations(lang)
 
   const docsPath = lang === i18n.defaultLanguage ? '/docs' : `/${lang}/docs`

--- a/source.config.ts
+++ b/source.config.ts
@@ -1,12 +1,9 @@
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config'
 
-import { i18n } from './app/lib/i18n'
-
 export const docs = defineDocs({
   dir: 'content/docs'
 })
 
 export default defineConfig({
-  lastModifiedTime: 'git',
-  i18n
+  lastModifiedTime: 'git'
 })


### PR DESCRIPTION
Fixes TypeScript errors by adding a locale type guard and widening translation return types. Updates docs, home, and image components to use typed locales, adjusts the custom search dialog for the current Fumadocs/Orama APIs, and removes unsupported i18n config from source.config.ts. Verification: pnpm typecheck.