### PR TITLE
fix: deploy script permission errors on tar extraction

### DIFF
--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -56,12 +56,10 @@ jobs:
           # Upload archive (scp uses -P for port)
           scp $SSH_KEY -P $PORT docs-build.tar.gz ${SSH_USER}@${SSH_HOST}:/tmp/docs-build.tar.gz
 
-          # Remote: backup, deploy, cleanup
+          # Remote: clean deploy directory and extract new build
           ssh $SSH_KEY -p $PORT ${SSH_USER}@${SSH_HOST} << DEPLOY
             set -e
-            rm -rf "${REMOTE_PATH}/.backup"
-            mkdir -p "${REMOTE_PATH}/.backup"
-            find "${REMOTE_PATH}" -maxdepth 1 -not -name '.backup' -not -path "${REMOTE_PATH}" -exec mv {} "${REMOTE_PATH}/.backup/" \;
+            find "${REMOTE_PATH}" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
             tar -xzf /tmp/docs-build.tar.gz -C "${REMOTE_PATH}"
             rm -f /tmp/docs-build.tar.gz
           DEPLOY


### PR DESCRIPTION
## 问题

CI 部署步骤 `Deploy via SCP and SSH` 失败，`tar` 解压时报满屏 `Cannot open: File exists` + `Cannot utime: Operation not permitted`。

**根因：** 部署脚本用 `find ... -exec mv {} .backup/` 清理旧文件，但当 SSH 用户不拥有某些文件时，`mv` 静默失败（`find` 本身返回 0，`set -e` 不会拦截）。旧文件留在原地 → `tar -xzf` 解压冲突。

## 修复

- 去掉 `.backup` 备份逻辑（内容都在 git 里，不需要服务器端备份）
- 改用 `find -mindepth 1 -maxdepth 1 -exec rm -rf {} +` 清空部署目录后再解压

## 变更

| 文件 | 改动 |
|---|---|
| `.github/workflows/docs-build-and-deploy.yml` | 部署步骤：`mv` → `rm -rf`，删除 `.backup` 相关逻辑 |